### PR TITLE
feat(scraping): 株式総数WARNINGに提出日基準優先による想定内乖離の注記を追加

### DIFF
--- a/src/main/java/github/com/ioridazo/fundanalyzer/domain/domain/specification/FinancialStatementSpecification.java
+++ b/src/main/java/github/com/ioridazo/fundanalyzer/domain/domain/specification/FinancialStatementSpecification.java
@@ -307,7 +307,7 @@ public class FinancialStatementSpecification {
                 SystemEventType.WARNING,
                 "FinancialStatementSpecification",
                 MessageFormat.format(
-                        "企業コード:{0} EDINET:{1} 財務諸表:{2} 科目ID:{3} 書類ID:{4} 当期末:{5} 前回期末:{6} 前回値:{7} 今回値:{8} 比率:{9}",
+                        "企業コード:{0} EDINET:{1} 財務諸表:{2} 科目ID:{3} 書類ID:{4} 当期末:{5} 前回期末:{6} 前回値:{7} 今回値:{8} 比率:{9}{10}",
                         company.code(),
                         company.edinetCode(),
                         fs.getName(),
@@ -317,9 +317,18 @@ public class FinancialStatementSpecification {
                         previousStatement.getPeriodEnd(),
                         previousValue,
                         currentValue,
-                        ratio
+                        ratio,
+                        validationWarningNote(fs)
                 )
         );
+    }
+
+    private String validationWarningNote(final FinancialStatementEnum fs) {
+        if (FinancialStatementEnum.TOTAL_NUMBER_OF_SHARES.equals(fs)) {
+            return " （参考: 株式総数は提出日現在発行数を優先して採用する仕様のため、"
+                   + "期末後の株式分割・株式併合・新株発行による想定内の乖離である可能性があります）";
+        }
+        return "";
     }
 
     private String formatRatio(final Long previousValue, final Long currentValue) {

--- a/src/test/java/github/com/ioridazo/fundanalyzer/domain/domain/specification/FinancialStatementSpecificationTest.java
+++ b/src/test/java/github/com/ioridazo/fundanalyzer/domain/domain/specification/FinancialStatementSpecificationTest.java
@@ -483,7 +483,9 @@ class FinancialStatementSpecificationTest {
                     eq(SystemEventType.WARNING),
                     eq("FinancialStatementSpecification"),
                     eq("企業コード:1234 EDINET:E12345 財務諸表:" + FinancialStatementEnum.TOTAL_NUMBER_OF_SHARES.getName()
-                            + " 科目ID:0 書類ID:DOC001 当期末:2026-03-31 前回期末:2025-03-31 前回値:0 今回値:1 比率:INF")
+                            + " 科目ID:0 書類ID:DOC001 当期末:2026-03-31 前回期末:2025-03-31 前回値:0 今回値:1 比率:INF"
+                            + " （参考: 株式総数は提出日現在発行数を優先して採用する仕様のため、"
+                            + "期末後の株式分割・株式併合・新株発行による想定内の乖離である可能性があります）")
             );
         }
 


### PR DESCRIPTION
## Summary
- 本番ダッシュボードのシステムイベントに通知されていた株式総数(TOTAL_NUMBER_OF_SHARES)の乖離WARNING10件（対象9社）を調査し、いずれも実在する株式分割・株式併合・新株発行によるもの（データ抽出バグではない）と確認した
- 原因は2026-07-19の`b43c5915`で導入した「提出日現在発行数を事業年度末現在発行数より優先して採用する」仕様であり、期末後に株式分割等があると比率が分割・併合比率どおりに大きく乖離する（設計どおりの挙動）
- 運用者が毎回外部調査しなくても想定内と判断できるよう、株式総数のWARNINGメッセージ（`FinancialStatementSpecification.notifyValidationWarning`）にのみ「提出日現在発行数優先による想定内の乖離」である旨の注記を追加した
- 他の財務諸表項目（貸借対照表・損益計算書等）のWARNINGメッセージは変更していない

## Test plan
- [x] `FinancialStatementSpecificationTest` を更新（株式総数WARNING時のメッセージ検証に注記文言を追加）
- [x] `./mvnw test -DexcludedGroups=playwright` — 918件、失敗0、エラー0、BUILD SUCCESS
- [x] 本番ダッシュボード(`/v3/index`)を再取得し、調査開始時点から新規WARNING/ERRORが増えていないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7Ncg45783R17EPqJHw3eq